### PR TITLE
Add TypeScript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "new_home_page",
   "version": "2.0.0",
+  "type": "module",
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "astro build",
@@ -8,7 +9,8 @@
     "preview": "astro preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test:e2e": "node --test e2e-tests/*test.js",
+    "type-check": "tsc --noEmit",
+    "test:e2e": "node --test e2e-tests/*.js",
     "test:unit": "vitest"
   },
   "devDependencies": {

--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import BaseLayout from '@/layouts/BaseLayout.astro';
 import ProfileHeader from './ProfileHeader.astro';
 import SocialLinks from './SocialLinks.astro';
 import LangSwitcher from './LangSwitcher.astro';
-import type { Locale } from '../i18n/config';
-import { messages } from '../i18n/messages';
+import type { Locale } from '@/i18n/config';
+import { messages } from '@/i18n/messages';
 
 interface Props {
   locale: Locale;

--- a/src/components/LangSwitcher.astro
+++ b/src/components/LangSwitcher.astro
@@ -1,7 +1,7 @@
 ---
 import './LangSwitcher.css';
-import type { Locale } from '../i18n/config';
-import { locales } from '../i18n/config';
+import type { Locale } from '@/i18n/config';
+import { locales } from '@/i18n/config';
 
 interface Props {
   current: Locale;

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,7 +1,7 @@
 ---
 import './SocialLinks.css';
 import Icon from './Icon.astro';
-import type { Messages } from '../i18n/messages';
+import type { Messages } from '@/i18n/messages';
 
 interface Props {
   links: Messages['links'];

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,7 @@
 /// <reference path="../.astro/types.d.ts" />
+
+// Custom module declarations for Astro components
+declare module '*.astro' {
+  const Component: any;
+  export default Component;
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import '@/styles/global.css';
 import './BaseLayout.css';
 import { siteMeta } from '../site';
 import type { Locale } from '../i18n/config';

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,7 +1,7 @@
 ---
-import HomePage from '../../components/HomePage.astro';
-import type { Locale } from '../../i18n/config';
-import { locales, defaultLocale } from '../../i18n/config';
+import HomePage from '@/components/HomePage.astro';
+import type { Locale } from '@/i18n/config';
+import { locales, defaultLocale } from '@/i18n/config';
 
 export function getStaticPaths() {
   return locales.map((code) => ({ params: { lang: code } }));

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import HomePage from '../components/HomePage.astro';
-import type { Locale } from '../i18n/config';
+import HomePage from '@/components/HomePage.astro';
+import type { Locale } from '@/i18n/config';
 const locale: Locale = 'en';
 ---
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*", "astro.config.mjs", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", "e2e-tests"]
+}


### PR DESCRIPTION
Add TypeScript configuration and module type to package.json

This commit introduces TypeScript support with a new tsconfig.json file for path aliases and strict type checking. It also updates package.json to include a type-check script and sets the module type. Additionally, it refactors import paths to use aliases for consistency across the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Standardized imports to use path aliases for cleaner, consistent module resolution.

- Chores
  - Adopted ES module format for the project.
  - Added a type-check script for faster feedback during development.
  - Introduced a stricter TypeScript configuration with project-wide path aliases.

- Tests
  - Updated end-to-end test pattern to simplify test discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->