### PR TITLE
Convert CommonJS to ES modules in e2e tests

### DIFF
--- a/e2e-tests/HomePage.js
+++ b/e2e-tests/HomePage.js
@@ -1,4 +1,4 @@
-class HomePage {
+export default class HomePage {
   constructor(page) {
     this.page = page;
     this.url = 'https://r3nya.ru';
@@ -27,5 +27,3 @@ class HomePage {
     telegram: 'https://t.me/r3nya',
   };
 }
-
-module.exports = HomePage;

--- a/e2e-tests/e2e.test.js
+++ b/e2e-tests/e2e.test.js
@@ -1,8 +1,7 @@
-const { test } = require('node:test');
-const assert = require('node:assert');
-const puppeteer = require('puppeteer');
-
-const HomePageObject = require('./HomePage');
+import { test } from 'node:test';
+import assert from 'node:assert';
+import puppeteer from 'puppeteer';
+import HomePageObject from './HomePage.js';
 
 test('Home page available', async (t) => {
   const browser = await puppeteer.launch({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "new_home_page",
   "version": "2.0.0",
+  "type": "module",
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "astro build",
@@ -8,7 +9,8 @@
     "preview": "astro preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test:e2e": "node --test e2e-tests/*test.js",
+    "type-check": "tsc --noEmit",
+    "test:e2e": "node --test e2e-tests/*.js",
     "test:unit": "vitest"
   },
   "devDependencies": {

--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import BaseLayout from '@/layouts/BaseLayout.astro';
 import ProfileHeader from './ProfileHeader.astro';
 import SocialLinks from './SocialLinks.astro';
 import LangSwitcher from './LangSwitcher.astro';
-import type { Locale } from '../i18n/config';
-import { messages } from '../i18n/messages';
+import type { Locale } from '@/i18n/config';
+import { messages } from '@/i18n/messages';
 
 interface Props {
   locale: Locale;

--- a/src/components/LangSwitcher.astro
+++ b/src/components/LangSwitcher.astro
@@ -1,7 +1,7 @@
 ---
 import './LangSwitcher.css';
-import type { Locale } from '../i18n/config';
-import { locales } from '../i18n/config';
+import type { Locale } from '@/i18n/config';
+import { locales } from '@/i18n/config';
 
 interface Props {
   current: Locale;

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,7 +1,7 @@
 ---
 import './SocialLinks.css';
 import Icon from './Icon.astro';
-import type { Messages } from '../i18n/messages';
+import type { Messages } from '@/i18n/messages';
 
 interface Props {
   links: Messages['links'];

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,7 @@
 /// <reference path="../.astro/types.d.ts" />
+
+// Custom module declarations for Astro components
+declare module '*.astro' {
+  const Component: any;
+  export default Component;
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import '@/styles/global.css';
 import './BaseLayout.css';
 import { siteMeta } from '../site';
 import type { Locale } from '../i18n/config';

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,7 +1,7 @@
 ---
-import HomePage from '../../components/HomePage.astro';
-import type { Locale } from '../../i18n/config';
-import { locales, defaultLocale } from '../../i18n/config';
+import HomePage from '@/components/HomePage.astro';
+import type { Locale } from '@/i18n/config';
+import { locales, defaultLocale } from '@/i18n/config';
 
 export function getStaticPaths() {
   return locales.map((code) => ({ params: { lang: code } }));

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import HomePage from '../components/HomePage.astro';
-import type { Locale } from '../i18n/config';
+import HomePage from '@/components/HomePage.astro';
+import type { Locale } from '@/i18n/config';
 const locale: Locale = 'en';
 ---
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,21 @@
+export type ProfileMeta = {
+  name: string;
+  title: string;
+  firstName: string;
+  lastName: string;
+  username: string;
+  gender: 'male' | 'female' | 'other';
+  avatar: string;
+};
+
+export type SiteMeta = {
+  author: string;
+  description: string;
+  themeColor: string;
+  yandexVerification: string;
+  openGraphDescription: string;
+  safariPinnedTabColor: string;
+  title: string;
+  keywords: string;
+  profile: ProfileMeta;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*", "astro.config.mjs", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", "e2e-tests"]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added TypeScript types for site and profile metadata to improve typing across the project.
- Refactor
  - Migrated test code to ES modules and standardized default exports.
  - Replaced relative imports with alias-based paths across components and pages.
  - Consolidated global style import paths.
- Tests
  - Updated E2E test runner configuration and file pattern.
- Chores
  - Introduced a strict TypeScript configuration with path aliases.
  - Enabled Astro component type recognition.
  - Added a type-check script and set the project to use ES modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->