### PR TITLE
fix(ci): pin pnpm/action-setup to working v6 commit

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@2e223e0f
         with:
           version: 10.30.3
 

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@2e223e0f
+        uses: pnpm/action-setup@2e223e0f0d2b8fd9872cbadb8b7428e5f8b5556d
         with:
           version: 10.30.3
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@2e223e0f
+        uses: pnpm/action-setup@2e223e0f0d2b8fd9872cbadb8b7428e5f8b5556d
         with:
           version: 10.30.3
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@2e223e0f
         with:
           version: 10.30.3
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@2e223e0f
         with:
           version: 10.30.3
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@2e223e0f
+        uses: pnpm/action-setup@2e223e0f0d2b8fd9872cbadb8b7428e5f8b5556d
         with:
           version: 10.30.3
 


### PR DESCRIPTION
## Summary
- Pin `pnpm/action-setup` to commit `2e223e0f` instead of using the `v5` tag
- The `v6` tag was updated with a broken self-installer that ignores the `version` input and always installs pnpm v11 (ref: [pnpm/action-setup#225](https://github.com/pnpm/action-setup/issues/225))
- The pinned commit correctly respects the `version: 10.30.3` input
- Updates all 3 workflows: `check-build.yml`, `e2e-tests.yml`, `gh-pages.yml`

## Test Plan
- [x] CI passes on all affected workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned versions of the pnpm setup action across build, e2e testing, and deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->