### PR TITLE
chore: set minimum release age for package updates

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimumReleaseAge=2880


### PR DESCRIPTION
Добавлена настройка minimum release age для задержки автообновлений пакетов.

- **pnpm**: `minimumReleaseAge=2880` (48 часов)

Это предотвращает немедленное применение свежих релизов Dependabot, давая время на выявление регрессий.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package management configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/r3nya/r3nya.github.io/pull/866)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->