### PR TITLE
chore(deps): move Tailwind Vite plugin to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:visual:update": "vitest run --config vitest.visual.config.ts -u"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "astro": "^6.4.6",
@@ -35,7 +36,6 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
-    "@tailwindcss/vite": "^4.3.0",
     "@zachleat/snow-fall": "^1.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,13 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.7.3
         version: 3.7.3
-      '@tailwindcss/vite':
-        specifier: ^4.3.0
-        version: 4.3.0(vite@7.3.5)
       '@zachleat/snow-fall':
         specifier: ^1.0.3
         version: 1.0.3
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@7.3.5)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1


### PR DESCRIPTION
## Summary
- Move `@tailwindcss/vite` from `dependencies` to `devDependencies`
- Update `pnpm-lock.yaml` importer metadata accordingly

## Verification
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run format:check`
- [x] `pnpm run test:unit`
- [x] `pnpm run build`

## Notes
- `pnpm run type-check` currently fails on the existing `baseUrl` deprecation under TypeScript 6 (`TS5101`). The PR CI does not run this script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized development dependencies to ensure correct placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->